### PR TITLE
grove: Modify modules to use the `degu` module

### DIFF
--- a/basic/battery/main.py
+++ b/basic/battery/main.py
@@ -1,5 +1,5 @@
 from machine import ADC
-import zcoap
+import degu
 import time
 import ujson
 
@@ -19,19 +19,11 @@ def battery_voltage():
     return v
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
-
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['battery'] = battery_voltage()
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(60)
-
-        cli.close()

--- a/basic/control_led/main.py
+++ b/basic/control_led/main.py
@@ -1,28 +1,23 @@
 import time
-import zcoap
+import degu
 import ujson
 from machine import Pin
 from machine import Signal
 
 def main():
-    path = 'thing/' + zcoap.eui64()
-    reported = {'state':{'reported':{}}}
-
-    addr = zcoap.gw_addr()
-    port = 5683
-    cli = zcoap.client((addr, port))
-
     pin = Pin(('GPIO_1', 5), Pin.OUT)
     led = Signal(pin, invert=True)
     led.off()
     led_status = 'OFF'
 
     while True:
+        reported = {'state': {'reported': {}}}
+
         reported['state']['reported']['led'] = led_status
 
-        cli.request_post(path, ujson.dumps(reported))
+        degu.request_post(ujson.dumps(reported))
 
-        received = cli.request_get(path)
+        received = degu.update_shadow()
         if received:
             try:
                 desired = ujson.loads(received)
@@ -38,8 +33,6 @@ def main():
                 pass
 
         time.sleep(1)
-
-    cli.close()
 
 if __name__ == "__main__":
     main()

--- a/basic/control_led/main.py
+++ b/basic/control_led/main.py
@@ -15,9 +15,9 @@ def main():
 
         reported['state']['reported']['led'] = led_status
 
-        degu.request_post(ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
 
-        received = degu.update_shadow()
+        received = degu.get_shadow()
         if received:
             try:
                 desired = ujson.loads(received)

--- a/basic/default/main.py
+++ b/basic/default/main.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
         print(ujson.dumps(reported))
         degu.update_shadow(ujson.dumps(reported))
 
-        received = degu.update_shadow()
+        received = degu.get_shadow()
 
         if received:
             led1.on()

--- a/basic/default/main.py
+++ b/basic/default/main.py
@@ -16,9 +16,9 @@ if __name__ == '__main__':
     while True:
         reported['state']['reported']['message'] = 'OK'
         print(ujson.dumps(reported))
-        degu.request_post(ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
 
-        received = degu.request_get()
+        received = degu.update_shadow()
 
         if received:
             led1.on()

--- a/basic/default/main.py
+++ b/basic/default/main.py
@@ -1,12 +1,11 @@
 from machine import Pin
 from machine import Signal
 from machine import ADC
-import zcoap
+import degu
 import time
 import ujson
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -15,19 +14,13 @@ if __name__ == '__main__':
     led1.off()
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['message'] = 'OK'
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.request_post(ujson.dumps(reported))
 
-        received = cli.request_get(path)
+        received = degu.request_get()
 
         if received:
             led1.on()
 
         time.sleep(5)
-
-        cli.close()

--- a/grove/2.5A_DC_Current_Sensor_ACS70331/main.py
+++ b/grove/2.5A_DC_Current_Sensor_ACS70331/main.py
@@ -1,6 +1,6 @@
 from machine import ADC
 from time import sleep
-import zcoap
+import degu
 import ujson
 
 
@@ -14,23 +14,17 @@ class Current:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     current = Current(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['current'] = current.read()
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(1)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/3-Axis_Digital_Accelerometer_1.5g/main.py
+++ b/grove/3-Axis_Digital_Accelerometer_1.5g/main.py
@@ -1,8 +1,7 @@
 import time
-import zcoap
+import degu
 import ujson
 import machine
-from sys import exit
 
 i2c = machine.I2C(1)
 
@@ -61,23 +60,17 @@ class MMC7660:
         return {'x': x, 'y': y, 'z': z}
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
-
 
     mmc7660 = MMC7660(MMC7660_I2CADDR)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['axis'] = mmc7660.getAxes()
 
-        print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        json = ujson.dumps(reported)
+        print(json)
+        degu.update_shadow(json)
         time.sleep(5)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/3-Axis_Digital_Accelerometer_16g/main.py
+++ b/grove/3-Axis_Digital_Accelerometer_16g/main.py
@@ -1,8 +1,7 @@
 import time
-import zcoap
+import degu
 import ujson
 import machine
-from sys import exit
 
 i2c = machine.I2C(1)
 
@@ -85,23 +84,16 @@ class ADXL345:
         return {'x': x, 'y': y, 'z': z}
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
-
 
     adxl345 = ADXL345(ADXL345_I2CADDR)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['axis'] = adxl345.getAxes()
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(5)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/3-Axis_Digital_Accelerometer_16g_BMA400/main.py
+++ b/grove/3-Axis_Digital_Accelerometer_16g_BMA400/main.py
@@ -1,8 +1,7 @@
 import time
-import zcoap
+import degu
 import ujson
 from machine import I2C
-from sys import exit
 
 # create an i2c on bus 1
 i2c = I2C(1)
@@ -153,24 +152,19 @@ class BMA400:
         time.sleep_us(10)
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     bma400 = BMA400(BMA400_I2CADDR)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['temp'] = bma400.temprature_read()
         reported['state']['reported']['axis'] = bma400.accel_axis_read()
 
-        print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        json = ujson.dumps(reported)
+        print(json)
+        degu.update_shadow(json)
         time.sleep(5)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/5V_DC_AC_Current_Sensor/main.py
+++ b/grove/5V_DC_AC_Current_Sensor/main.py
@@ -1,6 +1,6 @@
 from machine import ADC
 from time import sleep
-import zcoap
+import degu
 import ujson
 
 class Current:
@@ -21,24 +21,18 @@ class Current:
         return currentSum / 100
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     current = Current(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['current'] = current.read()
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(1)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/6-Axis_Accelerometer_and_Gyroscope/main.py
+++ b/grove/6-Axis_Accelerometer_and_Gyroscope/main.py
@@ -1,8 +1,7 @@
 import time
-import zcoap
+import degu
 import ujson
 from machine import I2C
-from sys import exit
 
 #create an i2c on bus 1
 i2c = I2C(1)
@@ -155,24 +154,18 @@ class LSM6DS3:
         time.sleep_us(10)
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     lsm6ds3 = LSM6DS3(0x6A, True, True) #device_addr, accel_mode, gyros_mode
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['accel'] = lsm6ds3.accel_start()
         reported['state']['reported']['gyro'] = lsm6ds3.gyros_start()
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(5)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/Adjustable_PIR_Motion_Sensor/main.py
+++ b/grove/Adjustable_PIR_Motion_Sensor/main.py
@@ -1,6 +1,6 @@
 from machine import Pin
 from utime import sleep
-import zcoap
+import degu
 import ujson
 
 
@@ -22,22 +22,16 @@ class PIR:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     vib = PIR(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['motion'] = vib.detect()
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(1)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/Air_Quality_Sensor/main.py
+++ b/grove/Air_Quality_Sensor/main.py
@@ -1,6 +1,6 @@
 from machine import ADC
 from time import sleep
-import zcoap
+import degu
 import ujson
 
 class AirQuality:
@@ -18,24 +18,18 @@ class AirQuality:
         return self.adc.read()
                 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     air = AirQuality(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['air_quality'] = air.read()
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(60)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/Barometer_Sensor_BME280/main.py
+++ b/grove/Barometer_Sensor_BME280/main.py
@@ -1,5 +1,5 @@
 import time
-import zcoap
+import degu
 import ujson
 from ustruct import unpack, unpack_from
 from array import array
@@ -177,7 +177,6 @@ class BME280:
                 "{}.{:02d}".format(hi, hd))
                 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -185,17 +184,13 @@ def main():
     bme = BME280(i2c=bus)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['temp'] = bme.values[0]
         reported['state']['reported']['pres'] = bme.values[1]
         reported['state']['reported']['humid'] = bme.values[2]
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(60)
-        cli.close()
+
 if __name__ == "__main__":
     main()

--- a/grove/Barometer_Sensor_BMP280/main.py
+++ b/grove/Barometer_Sensor_BMP280/main.py
@@ -1,5 +1,5 @@
 import time
-import zcoap
+import degu
 import ujson
 from ustruct import unpack, unpack_from
 from array import array
@@ -177,7 +177,6 @@ class BMP280:
                 "{}.{:02d}".format(hi, hd))
                 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -185,17 +184,12 @@ def main():
     bmp = BMP280(i2c=bus)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['temp'] = bmp.values[0]
         reported['state']['reported']['pres'] = bmp.values[1]
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(60)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/Button/main.py
+++ b/grove/Button/main.py
@@ -1,11 +1,8 @@
 from machine import Pin
-from machine import Signal
-import zcoap
-import time
+import degu
 import ujson
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -13,10 +10,6 @@ if __name__ == '__main__':
 
     before = 0
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         value = button.value()
         if value != before:
             if value == 0:
@@ -25,7 +18,5 @@ if __name__ == '__main__':
                 reported['state']['reported']['button'] = 'on'
 
             print(ujson.dumps(reported))
-            cli.request_post(path, ujson.dumps(reported))
+            degu.update_shadow(ujson.dumps(reported))
             before = value
-
-        cli.close()

--- a/grove/Buzzer/main.py
+++ b/grove/Buzzer/main.py
@@ -1,11 +1,8 @@
 from machine import Pin
-from machine import Signal
-import zcoap
-import time
+import degu
 import ujson
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -14,10 +11,6 @@ if __name__ == '__main__':
 
     before = 0
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         value = sw4.value()
         if value != before:
             if value == 1:
@@ -28,7 +21,5 @@ if __name__ == '__main__':
                 buzzer.on()
 
             print(ujson.dumps(reported))
-            cli.request_post(path, ujson.dumps(reported))
+            degu.update_shadow(ujson.dumps(reported))
             before = value
-
-        cli.close()

--- a/grove/CO2_Temperature_Humidity_Sensor/main.py
+++ b/grove/CO2_Temperature_Humidity_Sensor/main.py
@@ -1,6 +1,6 @@
 from machine import I2C
 from time import sleep
-import zcoap
+import degu
 import ujson
 from ustruct import unpack
 
@@ -32,14 +32,9 @@ class CO2:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         co2 = CO2()
 
         concentration = co2.getConcentration()
@@ -50,10 +45,9 @@ def main():
         }
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(60)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/Collision_Sensor/main.py
+++ b/grove/Collision_Sensor/main.py
@@ -1,6 +1,6 @@
 from machine import Pin
 from utime import sleep
-import zcoap
+import degu
 import ujson
 
 
@@ -22,22 +22,16 @@ class Collision:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     collision = Collision(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['collision'] = collision.detect()
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(1)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/GPS/main.py
+++ b/grove/GPS/main.py
@@ -1,6 +1,6 @@
 from machine import UART
 import time
-import zcoap
+import degu
 import ujson
 import math
 
@@ -80,23 +80,17 @@ class GPS:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
 
     gps = GPS(0, GPS_BAUDRATE)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported'] = gps.read(("gprmc", "gpgsa"))
         json = ujson.dumps(reported)
         print(json)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         time.sleep(1)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/High_Temperature_Sensor/main.py
+++ b/grove/High_Temperature_Sensor/main.py
@@ -1,8 +1,7 @@
 from machine import ADC
-from math import log
 from utime import sleep
 import ujson
-import zcoap
+import degu
 
 class Temperature:
     def __init__(self, port):
@@ -47,24 +46,18 @@ class Temperature:
         return value
          
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     temp = Temperature(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['temp'] = temp.read()
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(60)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/I2C_Color_sensor/main.py
+++ b/grove/I2C_Color_sensor/main.py
@@ -1,6 +1,6 @@
 from machine import I2C
 from time import sleep
-import zcoap
+import degu
 import ujson
 
 
@@ -50,16 +50,11 @@ class ColorSensor:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     colorSensor = ColorSensor()
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         color = colorSensor.readColor()
         reported['state']['reported']['color'] = {
             'red': color[0],
@@ -68,10 +63,9 @@ def main():
         }
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(60)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/LED_Socket_Kit/main.py
+++ b/grove/LED_Socket_Kit/main.py
@@ -1,11 +1,8 @@
 from machine import Pin
-from machine import Signal
-import zcoap
-import time
+import degu
 import ujson
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -14,10 +11,6 @@ if __name__ == '__main__':
 
     before = 0
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         value = sw4.value()
         if value != before:
             if value == 1:
@@ -28,7 +21,5 @@ if __name__ == '__main__':
                 led.on()
 
             print(ujson.dumps(reported))
-            cli.request_post(path, ujson.dumps(reported))
+            degu.update_shadow(ujson.dumps(reported))
             before = value
-
-        cli.close()

--- a/grove/Light_sensor/main.py
+++ b/grove/Light_sensor/main.py
@@ -1,5 +1,5 @@
 from machine import ADC
-import zcoap
+import degu
 import time
 import ujson
 
@@ -15,20 +15,13 @@ def light_sensor():
     return v
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         light = round(light_sensor(), 2)
         reported['state']['reported']['light'] = light
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(1)
-
-        cli.close()

--- a/grove/Loudness_Sensor/main.py
+++ b/grove/Loudness_Sensor/main.py
@@ -1,7 +1,7 @@
 from machine import ADC
 from utime import sleep
 import ujson
-import zcoap
+import degu
 
 class Loudness:
     def __init__(self, port):
@@ -25,24 +25,18 @@ class Loudness:
         return valueSum / count
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     loudness = Loudness(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['loudness'] = loudness.read()
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(1)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/Moisture_Sensor/main.py
+++ b/grove/Moisture_Sensor/main.py
@@ -1,7 +1,7 @@
 from machine import ADC
 from utime import sleep
 import ujson
-import zcoap
+import degu
 
 
 class Moisture:
@@ -26,23 +26,17 @@ class Moisture:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     moisture = Moisture(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['moisture'] = moisture.read()
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(30)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/Piezo_Vibration_Sensor/main.py
+++ b/grove/Piezo_Vibration_Sensor/main.py
@@ -1,6 +1,6 @@
 from machine import Pin
 from utime import sleep
-import zcoap
+import degu
 import ujson
 
 
@@ -22,22 +22,16 @@ class PiezoVibration:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     vibration = PiezoVibration(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['vibration'] = vibration.detect()
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(1)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/RTC/main.py
+++ b/grove/RTC/main.py
@@ -1,8 +1,8 @@
 from machine import I2C
 from time import sleep
-import zcoap
+import degu
 import ujson
-from ustruct import unpack
+
 
 class RTC:
     def __init__(self):
@@ -50,7 +50,6 @@ class RTC:
         return [2000 + year, month, day, dayOfWeek, hour, minute, second]
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -63,20 +62,16 @@ def main():
     formatString = "{}-{:0>2}-{:0>2}({:0>2}) {:0>2}:{:0>2}:{:0>2}"
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         time = rtc.getTime()
         reported['state']['reported']['time'] = {"time": formatString.format(
             time[0], time[1], time[2], days[time[3]], time[4], time[5], time[6]
         )}
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(1)
-        cli.close()
+
 
 if __name__ == "__main__":
     main() 

--- a/grove/Relay/main.py
+++ b/grove/Relay/main.py
@@ -1,11 +1,8 @@
 from machine import Pin
-from machine import Signal
-import zcoap
-import time
+import degu
 import ujson
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -14,10 +11,6 @@ if __name__ == '__main__':
 
     before = 0
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         value = sw4.value()
         if value != before:
             if value == 1:
@@ -28,7 +21,5 @@ if __name__ == '__main__':
                 relay.on()
 
             print(ujson.dumps(reported))
-            cli.request_post(path, ujson.dumps(reported))
+            degu.update_shadow(ujson.dumps(reported))
             before = value
-
-        cli.close()

--- a/grove/Rotary_Angle_sensor/main.py
+++ b/grove/Rotary_Angle_sensor/main.py
@@ -1,5 +1,5 @@
 from machine import ADC
-import zcoap
+import degu
 import time
 import ujson
 
@@ -18,19 +18,12 @@ def angle():
     return round(degrees)
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['angle'] = angle()
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(1)
-
-        cli.close()

--- a/grove/Round_Force_Sensor_FSR402/main.py
+++ b/grove/Round_Force_Sensor_FSR402/main.py
@@ -1,5 +1,5 @@
 from machine import ADC
-import zcoap
+import degu
 import time
 import ujson
 
@@ -15,20 +15,13 @@ def round_force_sensor():
     return raw
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         force = round_force_sensor()
         reported['state']['reported']['force'] = force
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(1)
-
-        cli.close()

--- a/grove/Screw_Termial/adc/main.py
+++ b/grove/Screw_Termial/adc/main.py
@@ -1,5 +1,5 @@
 from machine import ADC
-import zcoap
+import degu
 import time
 import ujson
 
@@ -24,21 +24,14 @@ def d2_voltage():
     return v
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         d1 = round(d1_voltage(), 2)
         d2 = round(d2_voltage(), 2)
         reported['state']['reported']['terminal'] = {'d1':d1, 'd2':d2}
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(1)
-
-        cli.close()

--- a/grove/Screw_Termial/dio/main.py
+++ b/grove/Screw_Termial/dio/main.py
@@ -1,11 +1,8 @@
 from machine import Pin
-from machine import Signal
-import zcoap
-import time
+import degu
 import ujson
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -15,10 +12,6 @@ if __name__ == '__main__':
 
     before = 0
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         value = sw4.value()
         if value != before:
             if value == 1:
@@ -31,7 +24,5 @@ if __name__ == '__main__':
                 terminal_d2.off()
 
             print(ujson.dumps(reported))
-            cli.request_post(path, ujson.dumps(reported))
+            degu.update_shadow(ujson.dumps(reported))
             before = value
-
-        cli.close()

--- a/grove/Sound_Sensor/main.py
+++ b/grove/Sound_Sensor/main.py
@@ -1,7 +1,7 @@
 from machine import ADC
 from utime import sleep
 import ujson
-import zcoap
+import degu
 
 
 class Loudness:
@@ -26,23 +26,17 @@ class Loudness:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     loudness = Loudness(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['loudness'] = loudness.read()
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(30)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/Temperature_Sensor/main.py
+++ b/grove/Temperature_Sensor/main.py
@@ -1,7 +1,7 @@
 from machine import ADC
 from utime import sleep
 import ujson
-import zcoap
+import degu
 import math
 
 
@@ -34,23 +34,17 @@ class Temperature:
 
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state': {'reported': {}}}
 
     temperature = Temperature(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['temperature'] = temperature.read()
 
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
         sleep(30)
-        cli.close()
 
 
 if __name__ == "__main__":

--- a/grove/Temperature_and_Humidity_Sensor_SHT31/main.py
+++ b/grove/Temperature_and_Humidity_Sensor_SHT31/main.py
@@ -1,5 +1,5 @@
 import time
-import zcoap
+import degu
 import ujson
 from machine import I2C
 
@@ -50,7 +50,6 @@ class SHT31(object):
         return temp, 100 * (h / 65535)
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -58,19 +57,14 @@ def main():
     sht31 = SHT31(i2c=bus)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         values = sht31.get_temp_humi()
 
         reported['state']['reported']['temp'] = values[0]
         reported['state']['reported']['humid'] = values[1]
 
         print(ujson.dumps(reported))
-        cli.request_post(path, ujson.dumps(reported))
+        degu.update_shadow(ujson.dumps(reported))
         time.sleep(60)
-        cli.close()
 
 if __name__ == "__main__":
     main()

--- a/grove/Touch/main.py
+++ b/grove/Touch/main.py
@@ -1,11 +1,8 @@
 from machine import Pin
-from machine import Signal
-import zcoap
-import time
+import degu
 import ujson
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -13,10 +10,6 @@ if __name__ == '__main__':
 
     before = 0
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         value = touch.value()
         if value != before:
             if value == 0:
@@ -25,7 +18,5 @@ if __name__ == '__main__':
                 reported['state']['reported']['touch'] = 'on'
 
             print(ujson.dumps(reported))
-            cli.request_post(path, ujson.dumps(reported))
+            degu.update_shadow(ujson.dumps(reported))
             before = value
-
-        cli.close()

--- a/grove/Vibration_Motor/main.py
+++ b/grove/Vibration_Motor/main.py
@@ -1,11 +1,8 @@
 from machine import Pin
-from machine import Signal
-import zcoap
-import time
+import degu
 import ujson
 
 if __name__ == '__main__':
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
@@ -14,10 +11,6 @@ if __name__ == '__main__':
 
     before = 0
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         value = sw4.value()
         if value != before:
             if value == 1:
@@ -28,7 +21,5 @@ if __name__ == '__main__':
                 vibration.on()
 
             print(ujson.dumps(reported))
-            cli.request_post(path, ujson.dumps(reported))
+            degu.update_shadow(ujson.dumps(reported))
             before = value
-
-        cli.close()

--- a/grove/Vibration_Sensor_SW-420/main.py
+++ b/grove/Vibration_Sensor_SW-420/main.py
@@ -1,6 +1,6 @@
 from machine import Pin
 from utime import ticks_ms, sleep
-import zcoap
+import degu
 import ujson
 
 class Vibration:
@@ -26,26 +26,20 @@ class Vibration:
         return result
 
 def main():
-    path = 'thing/' + zcoap.eui64()
     reported = {'state':{'reported':{}}}
 
 
     vib = Vibration(0)
 
     while True:
-        addr = zcoap.gw_addr()
-        port = 5683
-        cli = zcoap.client((addr, port))
-
         reported['state']['reported']['vibration'] = "not detected"
         for i in range(100):
             if vib.detect():
                 reported['state']['reported']['detected'] = "detected"
             sleep(0.01)
         json = ujson.dumps(reported)
-        cli.request_post(path, json)
+        degu.update_shadow(json)
         print(json)
-        cli.close()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Degu v1.0.0 or above will provide the `degu` module instead of the `zcoap` module.
This pull request modifies the modules to correspond to the change.